### PR TITLE
vendor: Fix Google dialer

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -120,7 +120,7 @@ PRODUCT_COPY_FILES += \
 
 # Fix Dialer
 PRODUCT_COPY_FILES +=  \
-#    vendor/xtended/prebuilt/common/sysconfig/dialer_experience.xml:system/etc/sysconfig/dialer_experience.xml
+    vendor/xtended/prebuilt/common/sysconfig/dialer_experience.xml:system/etc/sysconfig/dialer_experience.xml
 
 # Gzosp-specific startup services
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
* Add in dialer_experience.xml found in the factory image so if the user
decides to install it, they're not meant with a message about how is not
supported.